### PR TITLE
Fix: Replace np.float with float for NumPy compatibility

### DIFF
--- a/Language-Understanding-RoBERTa/bert_adapter/fairseq/data/indexed_dataset.py
+++ b/Language-Understanding-RoBERTa/bert_adapter/fairseq/data/indexed_dataset.py
@@ -86,7 +86,7 @@ dtypes = {
     3: np.int16,
     4: np.int32,
     5: np.int64,
-    6: np.float,
+    6: float,
     7: np.double,
     8: np.uint16
 }
@@ -289,7 +289,7 @@ class IndexedDatasetBuilder(object):
         np.int16: 2,
         np.int32: 4,
         np.int64: 8,
-        np.float: 4,
+        float: 4,
         np.double: 8
     }
 

--- a/Language-Understanding-RoBERTa/bert_compactor/fairseq/data/indexed_dataset.py
+++ b/Language-Understanding-RoBERTa/bert_compactor/fairseq/data/indexed_dataset.py
@@ -86,7 +86,7 @@ dtypes = {
     3: np.int16,
     4: np.int32,
     5: np.int64,
-    6: np.float,
+    6: float,
     7: np.double,
     8: np.uint16
 }
@@ -289,7 +289,7 @@ class IndexedDatasetBuilder(object):
         np.int16: 2,
         np.int32: 4,
         np.int64: 8,
-        np.float: 4,
+        float: 4,
         np.double: 8
     }
 

--- a/Language-Understanding-RoBERTa/bert_dpsgd/fairseq/data/indexed_dataset.py
+++ b/Language-Understanding-RoBERTa/bert_dpsgd/fairseq/data/indexed_dataset.py
@@ -86,7 +86,7 @@ dtypes = {
     3: np.int16,
     4: np.int32,
     5: np.int64,
-    6: np.float,
+    6: float,
     7: np.double,
     8: np.uint16
 }
@@ -289,7 +289,7 @@ class IndexedDatasetBuilder(object):
         np.int16: 2,
         np.int32: 4,
         np.int64: 8,
-        np.float: 4,
+        float: 4,
         np.double: 8
     }
 

--- a/Language-Understanding-RoBERTa/bert_lora/fairseq/data/indexed_dataset.py
+++ b/Language-Understanding-RoBERTa/bert_lora/fairseq/data/indexed_dataset.py
@@ -86,7 +86,7 @@ dtypes = {
     3: np.int16,
     4: np.int32,
     5: np.int64,
-    6: np.float,
+    6: float,
     7: np.double,
     8: np.uint16
 }
@@ -289,7 +289,7 @@ class IndexedDatasetBuilder(object):
         np.int16: 2,
         np.int32: 4,
         np.int64: 8,
-        np.float: 4,
+        float: 4,
         np.double: 8
     }
 


### PR DESCRIPTION
This PR replaces np.float with float in indexed_dataset.py to address compatibility with the latest NumPy versions. This resolves an AttributeError caused by the removal of np.float in NumPy 1.20.